### PR TITLE
support imgsumDatabasePath with space on windows

### DIFF
--- a/deduplicator.lrdevplugin/FindDuplicates.lua
+++ b/deduplicator.lrdevplugin/FindDuplicates.lua
@@ -62,7 +62,7 @@ function IndexPhoto(photo)
 
   local imagePath = photo:getRawMetadata("path")
   if WIN_ENV == true then
-    command = string.format('"%s" "%s" >> %s',
+    command = string.format('"%s" "%s" >> "%s"',
       LrPathUtils.child( LrPathUtils.child( _PLUGIN.path, "win" ), binName .. '.exe' ),
       imagePath,
       imgsumDatabasePath)


### PR DESCRIPTION
Only the command and args were quoted when executing imgsum on windows but if the path to the imgsumDatabasePath contained a space LrTasks.execute() would return 1

Quoting the imgsumDatabasePath fixes the issue